### PR TITLE
Release : Version 2.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [v2.1.5] - 2026-04-01
+
+### Security
+
+- **Forced `picomatch` to version 4.0.4** via npm overrides to patch Dependabot alert #54 — a method injection vulnerability (CWE-1321) in `POSIX_REGEX_SOURCE` where specially crafted POSIX bracket expressions (e.g., `[[:constructor:]]`) could reference inherited `Object.prototype` methods, leading to incorrect glob matching behavior.
+  - Affected transitive dependency: `picomatch@4.0.3` introduced via `eslint-config-next`
+- **Forced `brace-expansion` to version 5.0.5** via npm overrides to patch a zero-step sequence vulnerability causing process hang and memory exhaustion.
+- **Forced `yaml` to version 2.8.3** via npm overrides to patch a stack overflow vulnerability triggered by deeply nested YAML collections.
+- Investigated and dismissed `ajv` moderate vulnerability — cannot be patched without breaking ESLint compatibility. Affects dev tooling only, no production runtime exposure.
+- Regenerated `package-lock.json` to ensure all patched dependency versions are consistently applied.
+
+---
+
 ## [v2.1.4] - 2026-03-18
 
 ### Security

--- a/README.fr.md
+++ b/README.fr.md
@@ -90,7 +90,7 @@ Le projet suit la **[sémantique de versionnage](https://semver.org/lang/fr/)** 
 - **MINEUR** — Nouvelles fonctionnalités rétro-compatibles
 - **PATCH** — Corrections et améliorations mineures
 
-Dernière version stable : **v2.1.4**
+Dernière version stable : **v2.1.5**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The project follows **[Semantic Versioning](https://semver.org/)**:
 - **MINOR** — New features (backward-compatible)
 - **PATCH** — Fixes and performance improvements
 
-Latest stable version: **v2.1.4**
+Latest stable version: **v2.1.5**
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mowgli-tattoo-studio",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mowgli-tattoo-studio",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "dependencies": {
         "motion": "^12.23.24",
         "next": "^16.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2257,9 +2257,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5195,12 +5195,13 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -6330,19 +6331,6 @@
         }
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6770,15 +6758,19 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
-      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "glob": "13.0.0",
     "js-yaml": "4.1.1",
     "minimatch": "10.2.3",
-    "flatted": ">=3.4.0"
+    "flatted": ">=3.4.0",
+    "picomatch": ">=4.0.4",
+    "brace-expansion": ">=5.0.5",
+    "yaml": ">=2.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mowgli-tattoo-studio",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "private": true,
   "scripts": {
     "dev": "next dev -p 52055 -H 127.0.0.1",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,4 +1,4 @@
 export const mowgliCongif = {
-  version: "2.1.4",
+  version: "2.1.5",
   contactMail: "contact@mowgli-tattoo-studio.fr",
 };


### PR DESCRIPTION
## Security: Patch picomatch, brace-expansion and yaml vulnerabilities

Closes Dependabot alert #54

### Summary

This PR patches a method injection vulnerability in `picomatch` reported by Dependabot, and two additional vulnerabilities discovered via `npm audit` in `brace-expansion` and `yaml`.

### Vulnerabilities fixed

| Package | Vulnerability | Vulnerable version | Introduced via | Fixed version |
|---|---|---|---|---|
| `picomatch` | Method injection in POSIX character classes (CWE-1321) | `4.0.3` | `eslint-config-next` | `>=4.0.4` |
| `brace-expansion` | Zero-step sequence causes process hang and memory exhaustion | `4.0.0 - 5.0.4` | transitive | `>=5.0.5` |
| `yaml` | Stack overflow via deeply nested YAML collections | `2.0.0 - 2.8.2` | transitive | `>=2.8.3` |

> Note: a remaining `ajv` moderate vulnerability is present but cannot be patched without breaking ESLint compatibility. It affects dev tooling only and has been dismissed.

### Fix

Added overrides in `package.json` to force patched versions across all transitive dependencies:

```json
"overrides": {
  "glob": "13.0.0",
  "js-yaml": "4.1.1",
  "minimatch": "10.2.3",
  "flatted": ">=3.4.0",
  "picomatch": ">=4.0.4",
  "brace-expansion": ">=5.0.5",
  "yaml": ">=2.8.3"
}
```

### Testing

- `npm install` reduced vulnerabilities from 3 to 1 (remaining: `ajv`, dismissed)
- `npm run lint` passed (2 pre-existing `<img>` warnings, unrelated to this PR)
- `npm run build` passed successfully with all pages generated