### PR TITLE
fix: upgrade postcss to 8.5.10 and dismiss vendored Next.js instance (#60)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-config-next": "^16.2.3",
         "eslint-plugin-react-hooks": "^7.0.1",
         "globals": "^16.5.0",
-        "postcss": "^8",
+        "postcss": "^8.5.10",
         "postcss-url": "^10.1.3",
         "prettier": "^3.6.2",
         "prettier-plugin-tailwindcss": "^0.7.1",
@@ -4830,15 +4830,16 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -5274,9 +5275,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -5292,8 +5293,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint-config-next": "^16.2.3",
     "eslint-plugin-react-hooks": "^7.0.1",
     "globals": "^16.5.0",
-    "postcss": "^8",
+    "postcss": "^8.5.10",
     "postcss-url": "^10.1.3",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.7.1",


### PR DESCRIPTION
## Security: Patch postcss XSS vulnerability (#60)

Partially addresses Dependabot alert #60

### Summary

This PR upgrades the direct `postcss` devDependency to `^8.5.10` to patch an XSS vulnerability where `</style>` sequences in CSS values were not escaped during stringification, allowing injection into HTML `<style>` tags.

| Alert | Vulnerability | Severity | Affected versions | Fixed version |
|---|---|---|---|---|
| #60 | XSS via unescaped `</style>` in CSS stringify output | Moderate | `<8.5.10` | `8.5.10` |

### Remaining exposure

A second instance of `postcss@8.4.31` is vendored internally by `next@16.2.3` and cannot be patched via npm overrides (conflicts with direct dependency). The fix proposed by npm (`npm audit fix --force`) would downgrade Next.js to `9.3.3`, which is not acceptable.

This internal instance is used by Next.js for its own CSS pipeline processing — it is not used to embed user-supplied CSS into HTML `<style>` tags, so the XSS attack vector described in the advisory does not apply in this context. The remaining alert has been dismissed pending an upstream Next.js release that vendors `postcss >= 8.5.10`.

### Changes

- Upgraded `postcss` devDependency from `^8` to `^8.5.10`

### Testing

- `npm run lint` passed (2 pre-existing `<img>` warnings, unrelated to this PR)
- `npm run build` passed successfully with all pages generated