### PR TITLE
fix : correct typo in SkillsSection - 'fiers' -> 'fier'

### DIFF
--- a/src/common/sections/skills-section.tsx
+++ b/src/common/sections/skills-section.tsx
@@ -20,7 +20,7 @@ const skills = [
     icon: IconName.Couch,
     title: "Ambiance détendue",
     content:
-      "Le studio est propre et professionnel, mais aussi détendu et confortable. Je suis très fiers de chaque tatouage que je crée.",
+      "Le studio est propre et professionnel, mais aussi détendu et confortable. Je suis très fier de chaque tatouage que je crée.",
   },
 ];
 


### PR DESCRIPTION
## Fix: Correct typo in SkillsSection

### Change

Fixed a grammatical error in the skills section content:

- **Before:** `"Je suis très fiers de chaque tatouage que je crée."`
- **After:** `"Je suis très fier de chaque tatouage que je crée."`

### File affected

`src/common/sections/skills-section.tsx`