### PR TITLE
Release version 2.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [v2.1.9] - 2026-06-05
+
+### Fixed
+
+- Corrected grammatical error in the `SkillsSection` — "Je suis très fiers" → "Je suis très fier".
+
+---
+
 ## [v2.1.8] - 2026-05-13
 
 ### Security

--- a/README.fr.md
+++ b/README.fr.md
@@ -90,7 +90,7 @@ Le projet suit la **[sémantique de versionnage](https://semver.org/lang/fr/)** 
 - **MINEUR** — Nouvelles fonctionnalités rétro-compatibles
 - **PATCH** — Corrections et améliorations mineures
 
-Dernière version stable : **v2.1.8**
+Dernière version stable : **v2.1.9**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The project follows **[Semantic Versioning](https://semver.org/)**:
 - **MINOR** — New features (backward-compatible)
 - **PATCH** — Fixes and performance improvements
 
-Latest stable version: **v2.1.8**
+Latest stable version: **v2.1.9**
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mowgli-tattoo-studio",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mowgli-tattoo-studio",
-      "version": "2.1.8",
+      "version": "2.1.9",
       "dependencies": {
         "motion": "^12.23.24",
         "next": "^16.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mowgli-tattoo-studio",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "private": true,
   "scripts": {
     "dev": "next dev -p 52055 -H 127.0.0.1",

--- a/src/common/sections/skills-section.tsx
+++ b/src/common/sections/skills-section.tsx
@@ -20,7 +20,7 @@ const skills = [
     icon: IconName.Couch,
     title: "Ambiance détendue",
     content:
-      "Le studio est propre et professionnel, mais aussi détendu et confortable. Je suis très fiers de chaque tatouage que je crée.",
+      "Le studio est propre et professionnel, mais aussi détendu et confortable. Je suis très fier de chaque tatouage que je crée.",
   },
 ];
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,4 +1,4 @@
 export const mowgliCongif = {
-  version: "2.1.8",
+  version: "2.1.9",
   contactMail: "contact@mowgli-tattoo-studio.fr",
 };


### PR DESCRIPTION
## Fix: Correct typo in SkillsSection

### Change

Fixed a grammatical error in the skills section content:

- **Before:** `"Je suis très fiers de chaque tatouage que je crée."`
- **After:** `"Je suis très fier de chaque tatouage que je crée."`

### File affected

`src/sections/skills-section.tsx` (or equivalent path)