### PR TITLE
fix: patch nanoid infinite loop DoS and brace-expansion DoS (#91, #92)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-config-next": "^16.2.11",
         "eslint-plugin-react-hooks": "^7.0.1",
         "globals": "^16.5.0",
-        "postcss": "^8.5.18",
+        "postcss": "^8.5.23",
         "postcss-url": "^10.1.3",
         "prettier": "^3.6.2",
         "prettier-plugin-tailwindcss": "^0.7.1",
@@ -2569,9 +2569,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5135,9 +5135,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-6.0.1.tgz",
+      "integrity": "sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==",
       "funding": [
         {
           "type": "github",
@@ -5146,10 +5146,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^22 || ^24 || >=26"
       }
     },
     "node_modules/napi-postinstall": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint-config-next": "^16.2.11",
     "eslint-plugin-react-hooks": "^7.0.1",
     "globals": "^16.5.0",
-    "postcss": "^8.5.18",
+    "postcss": "^8.5.23",
     "postcss-url": "^10.1.3",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.7.1",
@@ -41,9 +41,10 @@
     "minimatch": "10.2.3",
     "flatted": ">=3.4.0",
     "picomatch": ">=4.0.4",
-    "brace-expansion": ">=5.0.8",
+    "brace-expansion": ">=5.0.9",
     "yaml": ">=2.8.3",
     "@babel/core": ">=7.29.6",
-    "sharp": ">=0.35.0"
+    "sharp": ">=0.35.0",
+    "nanoid": ">=3.3.17"
   }
 }


### PR DESCRIPTION
## Security: Patch nanoid, brace-expansion and postcss vulnerabilities

Closes Dependabot alerts #91, #92

### Vulnerabilities fixed

| Alert | Package | Vulnerability | Severity | Fixed version |
|---|---|---|---|---|
| #92 | `nanoid` | Infinite loop in `customAlphabet` and `customRandom` when `size` is 0 — DoS via thread hang | Moderate | `>=3.3.17` |
| #91 | `postcss` | Incomplete fix of GHSA-6g55-p6wh-862q — attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from` is unset | High | `^8.5.23` (devDependency) |
| — | `brace-expansion` | DoS via unbounded intermediate arrays bypassing the CVE-2026-14257 mitigation | High | `>=5.0.9` |

### Remaining dismissals

- `ajv` moderate — cannot be patched without breaking ESLint. Dev tooling only.
- `postcss` vendored by Next.js internally (`node_modules/next/node_modules/postcss@8.4.31`) — cannot be patched without downgrading to Next.js 9.3.3. Attack vector does not apply to Next.js internal CSS pipeline. Dismissed with "Vulnerable code is not actually used".

### Changes

- Added `nanoid: >=3.3.17` to npm overrides
- Updated `brace-expansion` override to `>=5.0.9`
- Upgraded `postcss` devDependency to `^8.5.23`

### Testing

- `npm run lint` passed (2 pre-existing `<img>` warnings, unrelated to this PR)
- `npm run build` passed successfully with all pages generated
- Next.js 16.2.12 confirmed in build output